### PR TITLE
chore : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN mv ./kubectl /usr/local/bin/
 
 
 #Upgrade pip
-RUN pip install --upgrade pip
+RUN pip install --no-cache-dir --upgrade pip
 
 
 # Copy the current directory contents into the container at /app
@@ -32,7 +32,7 @@ COPY . /app
 
 
 # Install any needed packages specified in requirements.txt
-RUN pip install --trusted-host pypi.python.org -r requirements.txt
+RUN pip install --no-cache-dir --trusted-host pypi.python.org -r requirements.txt
 
 
 WORKDIR /app/mla_app_code

--- a/mla_tenant_code/setup_container/Dockerfile
+++ b/mla_tenant_code/setup_container/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update
 RUN apt-get -y install curl
 RUN apt-get -y install tar
 RUN apt-get -y install python3-pip
-RUN pip3 install kubernetes
+RUN pip3 install --no-cache-dir kubernetes
 
 #####################################
 # COPY SETUP FILE TO CONTAINER

--- a/mla_tenant_code/view_container/Dockerfile
+++ b/mla_tenant_code/view_container/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get upgrade
 RUN apt-get -y install curl
 RUN apt-get -y install tar
 RUN apt-get -y install python3-pip
-RUN pip3 install kubernetes
-RUN pip3 install flask
+RUN pip3 install --no-cache-dir kubernetes
+RUN pip3 install --no-cache-dir flask
 
 #####################################
 # SETUP KUBECTL


### PR DESCRIPTION
using --no-cache-dir flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>